### PR TITLE
added geocoder on the search for postcode

### DIFF
--- a/app/javascript/controllers/geoform_controller.js
+++ b/app/javascript/controllers/geoform_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "stimulus"
+import MapboxGeocoder from "@mapbox/mapbox-gl-geocoder"
+
+export default class extends Controller {
+  static values = {apiKey: String}
+  static targets = [ "address"]
+
+  connect() {
+    this.geocoder = new MapboxGeocoder ({
+      accessToken: this.apiKeyValue,
+      types: "postcode, locality, neighborhood, address, poi"
+    });
+    this.geocoder.addTo(this.element)
+
+
+
+    this.geocoder.setPlaceholder("Post Code")
+    if (this.addressTarget.value != "") {
+      this.geocoder.setInput(this.addressTarget.value)
+    }
+
+    this.geocoder.on("result", event => this.#setInputValue(event))
+    this.geocoder.on("clear", () => this.#clearInputValue())
+  }
+  #setInputValue(event) {
+    this.addressTarget.value = event.result["place_name"]
+  }
+  #clearInputValue() {
+    this.addressTarget.value = ""
+  }
+}

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -3,7 +3,9 @@
 
 <div class="search-form">
   <%= form_with url: locations_path, method: :get, class: "d-flex" do |form| %>
-    <%= form.text_field :query, value: params[:query], placeholder: "Postcode/Location" %>
+    <div data-controller="geoform" data-geoform-api-key-value= <%= ENV['MAPBOX_API_KEY'] %> >
+      <%= form.text_field :query, value: params[:query], placeholder: "Postcode/Location", class: "d-none", data: {geoform_target: "address"} %>
+    </div>
     <%= form.number_field :distance, in: 1.0..70.0, step: 0.5, placeholder: "Distance: 1km", value: params[:distance] %>
     <%= form.submit "Search" %>
   <% end %>


### PR DESCRIPTION
user can now search via a geocoder input field (normal form input is hidden):
![image](https://user-images.githubusercontent.com/91392085/171298334-a0c3a20e-cc1b-42bc-a96e-46bc332664d1.png)

Upon submitting the form, the search term (e.g. postcode) is retained (rather than the field appearing empty), which I thought is a good UX. The issue in the moment is with the suggestions still appearing (dropping down below the input). Could not resolve at this point, will return to this at some point
![image](https://user-images.githubusercontent.com/91392085/171298505-661d0c80-1617-4092-8690-156bb67424bf.png)
